### PR TITLE
Cross-selling: changes for displaying cross-sell products (SHOOP-2181)

### DIFF
--- a/shoop_beauty_theme/templates/shoop_beauty_theme/shoop/front/macros.jinja
+++ b/shoop_beauty_theme/templates/shoop_beauty_theme/shoop/front/macros.jinja
@@ -61,7 +61,7 @@
 {% endmacro %}
 
 {% macro render_cross_sell_products(product, relation_type="", title="") %}
-    {%- set cross_sell_products = shoop.product.get_product_cross_sells(product, relation_type) %}
+    {%- set cross_sell_products = shoop.product.get_product_cross_sells(product, relation_type, count=8) %}
     {% if cross_sell_products %}
         <section class="carousel-section">
             {% if title %}

--- a/shoop_beauty_theme/templates/shoop_beauty_theme/shoop/front/product/detail.jinja
+++ b/shoop_beauty_theme/templates/shoop_beauty_theme/shoop/front/product/detail.jinja
@@ -127,7 +127,7 @@
         {% endif %}
 
         {{ macros.render_cross_sell_products(
-            product, relation_type="related", title=_("Related products")
+            product, relation_type="computed", title=_("Users who bought this product also bought")
         ) }}
 
         {{ macros.render_cross_sell_products(
@@ -135,9 +135,8 @@
         ) }}
 
         {{ macros.render_cross_sell_products(
-            product, relation_type="computed", title=_("Users who bought this product also bought")
+            product, relation_type="related", title=_("Related products")
         ) }}
-
     </div>
 
 {% endblock %}


### PR DESCRIPTION
- Show up to 8 cross sell products in product detail
- Change cross sells slides order to computed, recommended and
  related in product detail

Refs SHOOP-2181
